### PR TITLE
add fastforward;reduce sound delay

### DIFF
--- a/src/drivers/dingux-sdl/dingoo-sound.cpp
+++ b/src/drivers/dingux-sdl/dingoo-sound.cpp
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 
 #include "dingoo.h"
+#include "keyscan.h"
 
 #include "../common/configSys.h"
 
@@ -168,11 +169,23 @@ uint32 GetBufferedSound(void) {
     return s_BufferIn;
 }
 
+// a hack to check DINGOO_R hotkey combo
+static int ispressed(int sdlk_code)
+{
+	Uint8 *keystate = SDL_GetKeyState(NULL);
+
+	if(keystate[sdlk_code]) return 1;
+
+	return 0;
+}
 /**
  * Send a sound clip to the audio subsystem.
  */
 void WriteSound(int32 *buf, int Count) 
 {
+    if(ispressed(DINGOO_L)) {
+        Count /= 2;
+    }
     //extern int EmulationPaused;
 
     SDL_LockAudio();
@@ -195,7 +208,7 @@ _exit:
 
     // If we have too much audio, wait a bit before accepting more.
     // This keeps the lag in check.
-    while (GetBufferedSound() > 3 * GetBufferSize())
+    while (GetBufferedSound() >= 2 * GetBufferSize())
         usleep(1000);
 }
 


### PR DESCRIPTION
# fastforward
This repo has code for fastforward/slowforward by using `IncreaseEmulationSpeed/DecreaseEmulationSpeed`. BUT the code dont handle `g_fpsScale`, it uses `WriteSound` to handle vsync.  
retrogame is able to run at 122fps on nes games, when making half of sound data, it runs at 120fps.   
button `L` is used to toggle that.

# delay of sound
the delay of sound is about `(512(frame size, of 2*S16)/32000(snd samples) * 3)` ~= 3 nes frames ~= 50ms`. Reduce it to 2 nes frames.