### PR TITLE
Create overclock section in menu

### DIFF
--- a/src/drivers/dingux-sdl/config.cpp
+++ b/src/drivers/dingux-sdl/config.cpp
@@ -26,6 +26,15 @@
 #include <windows.h>
 #endif
 
+/* Declare global overclocking variables */
+extern bool overclock_enabled;
+//extern bool overclocking;
+extern bool skip_7bit_overclocking;
+extern int normalscanlines;
+extern int totalscanlines;
+extern int postrenderscanlines;
+extern int vblankscanlines;
+
 /**
  * Read a custom pallete from a file and load it into the core.
  */
@@ -145,6 +154,12 @@ Config * InitConfig() {
 	// scanline settings
 	config->addOption("slstart", "SDL.ScanLineStart", 0);
 	config->addOption("slend", "SDL.ScanLineEnd", 239);
+
+    // overclocking settings
+    config->addOption("ocenabled", "SDL.OverclockEnabled", 0);
+    config->addOption("skip7bitoc", "SDL.Skip7BitOverclocking", 0);
+    config->addOption("vblanksls", "SDL.VBlankScanLines", 0);
+    config->addOption("postrendersls", "SDL.PostRenderScanLines", 0);
 
 	// video controls
 	config->addOption('x', "xres", "SDL.XResolution", 320);
@@ -438,4 +453,13 @@ void UpdateEMUCore(Config *config) {
 #endif
 
 	FCEUI_SetRenderedLines(start, end, start, end);
+
+    // Overclock settings
+    config->getOption("SDL.OverclockEnabled", &flag);
+    overclock_enabled = flag ? true : false;
+    config->getOption("SDL.Skip7BitOverclocking", &flag);
+    skip_7bit_overclocking = flag ? true : false;
+    config->getOption("SDL.VBlankScanLines", &vblankscanlines);
+    config->getOption("SDL.PostRenderScanlines", &postrenderscanlines);
+    totalscanlines = normalscanlines + (overclock_enabled ? postrenderscanlines : 0);
 }

--- a/src/drivers/dingux-sdl/gui/overclock_settings.cpp
+++ b/src/drivers/dingux-sdl/gui/overclock_settings.cpp
@@ -1,0 +1,184 @@
+
+// Externals
+extern Config *g_config;
+
+/* MENU COMMANDS */
+
+// Overclock enabled
+static void ocenabled_update(unsigned long key)
+{
+	int val;
+	g_config->getOption("SDL.OverclockEnabled", &val);
+
+	if (key == DINGOO_RIGHT) val = 1;
+	if (key == DINGOO_LEFT) val = 0;
+
+	g_config->setOption("SDL.OverclockEnabled", val);
+}
+
+// Skip 7bit overlocking
+static void skip7bitoc_update(unsigned long key)
+{
+	int val;
+	g_config->getOption("SDL.Skip7BitOverclocking", &val);
+
+	if (key == DINGOO_RIGHT) val = 1;
+	if (key == DINGOO_LEFT) val = 0;
+
+	g_config->setOption("SDL.Skip7BitOverclocking", val);
+}
+
+// Vblank Scanlines
+static void vblanksls_update(unsigned long key)
+{
+	int val;
+	g_config->getOption("SDL.VBlankScanLines", &val);
+
+	if (key == DINGOO_RIGHT) val = val < 520 ? val+10 : 520;
+	if (key == DINGOO_LEFT) val = val > 0 ? val-10 : 0;
+
+	g_config->setOption("SDL.VBlankScanLines", val);
+}
+
+// Post-render Scanlines
+static void postrendersls_update(unsigned long key)
+{
+	int val;
+	g_config->getOption("SDL.PostRenderScanLines", &val);
+
+	if (key == DINGOO_RIGHT) val = val < 520 ? val+10 : 520;
+	if (key == DINGOO_LEFT) val = val > 0 ? val-10 : 0;
+
+	g_config->setOption("SDL.PostRenderScanLines", val);
+}
+
+/* TIMING SETTINGS MENU */
+static SettingEntry oc_menu[] =
+{
+	{ "Overclock Enabled", "Enables Overclock settings", "SDL.OverclockEnabled", ocenabled_update },
+	{ "Skip 7bit overclocking", "Don't Overclock 7bit samples", "SDL.Skip7BitOverclocking", skip7bitoc_update },
+	{ "VBlank Scanlines", "# of extra VBlank scanlines", "SDL.VBlankScanLines", vblanksls_update },
+	{ "Post-rend Scanlines", "# of post-render scanlines", "SDL.PostRenderScanLines", postrendersls_update },
+};
+
+int RunOverclockSettings()
+{
+	static int index = 0;
+	static int spy = 72;
+	int done = 0, y, i;
+
+	char tmp[32];
+	int  itmp;
+
+	static const int menu_size = sizeof(oc_menu) / sizeof(oc_menu[0]);
+	static const int max_entries = 8;
+	static int offset_start = 0;
+	static int offset_end = menu_size > max_entries ? max_entries : menu_size;
+
+	g_dirty = 1;
+	while (!done) {
+		// Parse input
+		readkey();
+		if (parsekey(DINGOO_B)) done = 1;
+
+		if (parsekey(DINGOO_UP, 1)) {
+			if (index > 0) {
+				index--;
+
+				if (index >= offset_start)
+					spy -= 15;
+
+				if ((offset_start > 0) && (index < offset_start)) {
+					offset_start--;
+					offset_end--;
+				}
+			} else {
+				index = menu_size-1;
+				offset_end = menu_size;
+				offset_start = menu_size <= max_entries ? 0 : offset_end - max_entries;
+				spy = 72 + 15*(index - offset_start);
+			}
+		}
+
+		if (parsekey(DINGOO_DOWN, 1)) {
+			if (index < (menu_size - 1)) {
+				index++;
+
+				if (index < offset_end)
+					spy += 15;
+
+				if ((offset_end < menu_size) && (index >= offset_end)) {
+					offset_end++;
+					offset_start++;
+				}
+			} else {
+				index = 0;
+				offset_start = 0;
+				offset_end = menu_size <= max_entries ? menu_size : max_entries;
+				spy = 72;
+			}
+		}
+
+		if (parsekey(DINGOO_RIGHT, 1) || parsekey(DINGOO_LEFT, 1)) {
+			oc_menu[index].update(g_key);
+		}
+
+		// Draw stuff
+		if( g_dirty )
+		{
+			draw_bg(g_bg);
+
+			//Draw Top and Bottom Bars
+			DrawChar(gui_screen, SP_SELECTOR, 0, 37);
+			DrawChar(gui_screen, SP_SELECTOR, 81, 37);
+			DrawChar(gui_screen, SP_SELECTOR, 0, 225);
+			DrawChar(gui_screen, SP_SELECTOR, 81, 225);
+			DrawText(gui_screen, "B - Go Back", 235, 225);
+			DrawChar(gui_screen, SP_LOGO, 12, 9);
+
+			// Draw selector
+			DrawChar(gui_screen, SP_SELECTOR, 56, spy);
+			DrawChar(gui_screen, SP_SELECTOR, 77, spy);
+
+			DrawText(gui_screen, "Overclock Settings", 8, 37);
+
+			// Draw menu
+			// for(i=0,y=72;i <= menu_size;i++,y+=15) {
+			for (i = offset_start, y = 72; i < offset_end; i++, y += 15) {
+				DrawText(gui_screen, oc_menu[i].name, 60, y);
+
+				g_config->getOption(oc_menu[i].option, &itmp);
+				if (!strncmp(oc_menu[i].name, "Overclock Enabled", 17)) {
+					sprintf(tmp, "%s", itmp ? "on" : "off");
+				} else if(!strncmp(oc_menu[i].name, "Skip 7bit overclocking", 22)) {
+					sprintf(tmp, "%s", itmp ? "on" : "off");
+                }
+				else sprintf(tmp, "%d", itmp);
+
+				DrawText(gui_screen, tmp, 210, y);
+			}
+
+			// Draw info
+			DrawText(gui_screen, oc_menu[index].info, 8, 225);
+
+			// Draw offset marks
+			if (offset_start > 0)
+				DrawChar(gui_screen, SP_UPARROW, 157, 62);
+			if (offset_end < menu_size)
+				DrawChar(gui_screen, SP_DOWNARROW, 157, 203);
+
+			g_dirty = 0;
+		}
+
+		SDL_Delay(16);
+
+		// Update real screen
+		FCEUGUI_Flip();
+	}
+
+	// Clear screen
+	dingoo_clear_video();
+
+	g_dirty = 1;
+	return 0;
+}

--- a/src/drivers/dingux-sdl/gui/settings_menu.cpp
+++ b/src/drivers/dingux-sdl/gui/settings_menu.cpp
@@ -11,6 +11,7 @@ typedef struct _setting_entry {
 #include "video_settings.cpp"
 #include "sound_settings.cpp"
 #include "control_settings.cpp"
+#include "overclock_settings.cpp"
 
 // #define SETTINGS_MENUSIZE 5
 
@@ -28,6 +29,10 @@ static void cmd_sound_settings(unsigned long key) {
 
 static void cmd_control_settings(unsigned long key) {
 	RunControlSettings();
+}
+
+static void cmd_oc_settings(unsigned long key) {
+	RunOverclockSettings();
 }
 
 static void cmd_config_save(unsigned long key) {
@@ -62,6 +67,7 @@ static SettingEntry settings_menu[] =
 	{ "Video", "Change video settings", "NULL", cmd_video_settings },
 	{ "Audio", "Change sound settings", "NULL", cmd_sound_settings },
 	{ "Input", "Change control settings", "NULL", cmd_control_settings },
+	{ "Overclock", "Change NES overclock settings", "NULL", cmd_oc_settings },
 	{ "Game Genie", "Emulate Game Genie", "SDL.GameGenie", gg_update },
 	{ "Save settings",	"Save as default settings", "NULL", cmd_config_save }
 };


### PR DESCRIPTION
Settings are mapped to existing nes overclocking global variables in the ppu
implementation.

I mimicked the way they were applied from the Windows implementation:
https://github.com/pingflood/fceux/blob/master/src/drivers/win/timing.cpp#L35

