### PR TITLE
Fix (opendingux): memory overalloc for palette

### DIFF
--- a/src/drivers/dingux-sdl/dingoo-video.cpp
+++ b/src/drivers/dingux-sdl/dingoo-video.cpp
@@ -63,7 +63,7 @@ int FDSSwitchRequested = 0;
 #define NOFFSET	(s_clipSides ? 8 : 0)
 
 /* Blur effect taken from vidblit.cpp */
-uint32 palettetranslate[65536 * 4];
+uint32 palettetranslate[65536];
 static uint32 CBM[3] = { 63488, 2016, 31 };
 static uint16 s_psdl[256];
 

--- a/src/drivers/dingux-sdl/scaler.cpp
+++ b/src/drivers/dingux-sdl/scaler.cpp
@@ -5,7 +5,7 @@
 #define AVERAGEHI(AB) ((((AB) & 0xF7DE0000) >> 1) + (((AB) & 0xF7DE) << 15))
 #define AVERAGELO(CD) ((((CD) & 0xF7DE) >> 1) + (((CD) & 0xF7DE0000) >> 17))
 
-extern uint32 palettetranslate[65536 * 4];
+extern uint32 palettetranslate[65536];
 
 /*
 	Upscale 256x224 -> 320x240


### PR DESCRIPTION
Saves 768kB of statically allocated RAM.
The pallette index never exceeds 64k offset.